### PR TITLE
Scala 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,9 +97,9 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.source.version>1.8</java.source.version>
         <java.target.version>1.8</java.target.version>
-        <scala.dependencies.version>2.11</scala.dependencies.version>
-        <scala.version>2.11.8</scala.version>
-        <specs2.version>3.7</specs2.version>
+        <scala.dependencies.version>2.12</scala.dependencies.version>
+        <scala.version>2.12.4</scala.version>
+        <specs2.version>3.8.9</specs2.version>
         <gpg.key>F3FA6878</gpg.key>
     </properties>
     


### PR DESCRIPTION
We need to publish our OSS with Scala 2.12 now.